### PR TITLE
Bug preventing activation?

### DIFF
--- a/video-js.php
+++ b/video-js.php
@@ -217,12 +217,12 @@ function video_shortcode($atts, $content=null){
     //Watermark
     if($watermark){
         $dataSetup['plugins'] = array(
-            ['watermark'] => array(
-                    ['file'] => $watermark,
-                    ['xpos'] => $wmxpos,
-                    ['ypos'] => $wmxpos,
-                    ['xrepeat'] => $wmxrepeat,
-                    ['opacity'] => $wmopacity
+            'watermark' => array(
+                    'file' => $watermark,
+                    'xpos' => $wmxpos,
+                    'ypos' => $wmxpos,
+                    'xrepeat' => $wmxrepeat,
+                    'opacity' => $wmopacity
             )
         );
     }


### PR DESCRIPTION
I was getting a parse error on activation. Am I right in thinking the
square brackets shouldn't be there? Removing the square brackets means
the plugin activates, but none of my videos have any controls on them
and I can't get them to play...

Cheers
Jon